### PR TITLE
operator and advocate signoffs

### DIFF
--- a/lib/dq.py
+++ b/lib/dq.py
@@ -401,7 +401,7 @@ class VirgoDQ():
         '''
         dirname = "%s/%s/"%(directory, self.graceDBevent.get_randStr())
         if not os.path.exists(dirname):
-            os.mkdirs(dirname)
+            os.mkdir(dirname)
         txtFileName = "%sVirgo_%s_%d_DQ_META.txt"%(dirname, self.graceDBevent.__graceid__, self.start)
         open(txtFileName,'w').close()
         return txtFileName

--- a/lib/dq.py
+++ b/lib/dq.py
@@ -401,7 +401,7 @@ class VirgoDQ():
         '''
         dirname = "%s/%s/"%(directory, self.graceDBevent.get_randStr())
         if not os.path.exists(dirname):
-            os.mkdir(dirname)
+            os.makedirs(dirname)
         txtFileName = "%sVirgo_%s_%d_DQ_META.txt"%(dirname, self.graceDBevent.__graceid__, self.start)
         open(txtFileName,'w').close()
         return txtFileName

--- a/lib/humans.py
+++ b/lib/humans.py
@@ -42,9 +42,9 @@ class HumanSignoff(object):
         flip a coinc and decide if we get an OK or a NO label
         '''
         if random.random() < self.respondSuccess: ### we succeed -> OK label
-            return "%sOK"%(self.name)
+            return "OK"
         else: ### we reject -> NO label
-            return "%sNO"%(self.name)
+            return "NO"
 
     def genSchedule(self, request=True, respond=True):
         '''
@@ -62,7 +62,7 @@ class HumanSignoff(object):
                 ### currently, RemoveLable is not implemented...
 #                remove = schedule.RemoveLabel( respond_dt, self.graceDBevent, self.request(), gdb_url=self.gdb_url )
 #                sched.insert( remove )
-            respond = schedule.WriteLabel( respond_dt, self.graceDBevent, self.decide(), gdb_url=self.gdb_url )
+            respond = schedule.WriteSignoff( respond_dt, self.graceDBevent, self.instrument, self.signoff_type, self.decide(), gdb_url=self.gdb_url)
             sched.insert( respond )
         return sched
 
@@ -79,6 +79,8 @@ class Site(HumanSignoff):
     def __init__(self, siteName, graceDBevent, respondTimeout=60.0, respondJitter=10.0, respondProb=1.0, respondProbOfSuccess=1.0, requestTimeout=0.0, requestJitter=0.0, gdb_url='https://gracedb.ligo.org/api/'):
         assert siteName in self.knownSites, 'siteName=%s is not in the list of known sites'%siteName ### ensure we know about this site
         self.name = siteName
+        self.instrument = siteName
+        self.signoff_type = 'OP'
         super(Site, self).__init__(graceDBevent, 
                                    gdb_url=gdb_url,
                                    requestTimeout=requestTimeout, 
@@ -96,4 +98,16 @@ class Adv(HumanSignoff):
     '''
     signoff from EM Advocates
     '''
-    name = 'ADV'
+    def __init__(self, graceDBevent, respondTimeout=60.0, respondJitter=10.0, respondProb=1.0, respondProbOfSuccess=1.0, requestTimeout=0.0, requestJitter=0.0, gdb_url='https://gracedb.ligo.org/api/'):
+        self.name = 'ADV'
+        self.instrument = ''
+        self.signoff_type = 'ADV'
+        super(Site, self).__init__(graceDBevent, 
+                                   gdb_url=gdb_url,
+                                   requestTimeout=requestTimeout, 
+                                   requestJitter=requestTimeout,
+                                   respondTimeout=respondTimeout,
+                                   respondJitter=respondJitter,
+                                   respondProb=respondProb,
+                                   respondProbOfSuccess=respondProbOfSuccess,
+                                  )

--- a/lib/humans.py
+++ b/lib/humans.py
@@ -102,7 +102,7 @@ class Adv(HumanSignoff):
         self.name = 'ADV'
         self.instrument = ''
         self.signoff_type = 'ADV'
-        super(Site, self).__init__(graceDBevent, 
+        super(Adv, self).__init__(graceDBevent, 
                                    gdb_url=gdb_url,
                                    requestTimeout=requestTimeout, 
                                    requestJitter=requestTimeout,

--- a/lib/ligoTest/gracedb/rest.py
+++ b/lib/ligoTest/gracedb/rest.py
@@ -499,9 +499,10 @@ class FakeDb():
         raise NotImplementedError('this is not implemented in the real GraceDb, so we do not implement it here. At least, not yet.')
 
     def __signoff__(self, graceid, instrument, signoff_type, status ):
+        signoff = '{0}{1}'.format(instrument, status) if instrument else '{0}{1}'.format(signoff_type, status)
         jsonD = {'self':self.__labelsPath__(graceid),
                  'creator':getpass.getuser(),
-                 'name':'{0}{1}'.format(instrument, status) if instrument else '{0}{1}'.format(signoff_type, status),
+                 'name':signoff,
                  'created':time.time(),
                 } # we use the labelsPath because when we query FakeTTP for H1OK, etc they are recorded as labels and need to be in the labels.pkl file
         lvalert = {'uid':graceid,
@@ -509,6 +510,11 @@ class FakeDb():
                    'object': {'instrument':instrument, 'signoff_type':signoff_type, 'status':status},
                    'file':'',
                   }
+
+        self.writeLog( graceid, 'applying label from signoff : %s'%signoff )
+        self.__append__( jsonD, self.__labelsPath__(graceid) )
+
+        return jsonD, lvalert
 
     def writeSignoff(self, graceid, instrument, signoff_type, status):
         signoff = '{0}{1}'.format(instrument, status) if instrument else '{0}{1}'.format(signoff_type, status)

--- a/lib/ligoTest/gracedb/rest.py
+++ b/lib/ligoTest/gracedb/rest.py
@@ -91,8 +91,8 @@ class FakeDb():
 
     __allowedSignoffs__ = ['H1OK' , 'H1NO',
                            'L1OK' , 'L1NO',
-                           'V1OK' , 'V1NO'
-                           'ADVOK', 'ADVNO'
+                           'V1OK' , 'V1NO',
+                           'ADVOK', 'ADVNO',
                           ]
 
     ### basic instantiation ###

--- a/lib/ligoTest/gracedb/rest.py
+++ b/lib/ligoTest/gracedb/rest.py
@@ -89,6 +89,12 @@ class FakeDb():
                          'V1OPS', 'V1OK', 'V1NO',
                         ]
 
+    __allowedSignoffs__ = ['H1OK' , 'H1NO',
+                           'L1OK' , 'L1NO',
+                           'V1OK' , 'V1NO'
+                           'ADVOK', 'ADVNO'
+                          ]
+
     ### basic instantiation ###
 
     def __init__(self, directory='.'):
@@ -132,7 +138,9 @@ class FakeDb():
         if not os.path.exists(self.__directory__(graceid)):
             raise FakeTTPError('could not find graceid=%s'%graceid)
 
-
+    def check_signoff(self, signoff):
+        if signoff not in self.__allowedSignoffs__:
+            raise FakeTTPError('signoff=%s not allowed'%signoff)
 
     ### generic utils and data management ###
 
@@ -489,6 +497,27 @@ class FakeDb():
         self.check_graceid(graceid)
 
         raise NotImplementedError('this is not implemented in the real GraceDb, so we do not implement it here. At least, not yet.')
+
+    def __signoff__(self, graceid, instrument, signoff_type, status ):
+        jsonD = {'self':self.__labelsPath__(graceid),
+                 'creator':getpass.getuser(),
+                 'name':'{0}{1}'.format(instrument, status) if instrument else '{0}{1}'.format(signoff_type, status),
+                 'created':time.time(),
+                } # we use the labelsPath because when we query FakeTTP for H1OK, etc they are recorded as labels and need to be in the labels.pkl file
+        lvalert = {'uid':graceid,
+                   'alert_type':'signoff',
+                   'object': {'instrument':instrument, 'signoff_type':signoff_type, 'status':status},
+                   'file':'',
+                  }
+
+    def writeSignoff(self, graceid, instrument, signoff_type, status):
+        signoff = '{0}{1}'.format(instrument, status) if instrument else '{0}{1}'.format(signoff_type, status)
+        self.check_graceid(graceid)
+        self.check_signoff( signoff )
+
+        jsonD, lvalert = self.__signoff__( graceid, instrument, signoff_type, status )
+        self.sendlvalert( lvalert, self.__node__(graceid) )
+        return FakeTTPResponse(jsonD)
 
     ### queries ###
 

--- a/lib/ligoTest/gracedb/rest.py
+++ b/lib/ligoTest/gracedb/rest.py
@@ -507,6 +507,7 @@ class FakeDb():
                 } # we use the labelsPath because when we query FakeTTP for H1OK, etc they are recorded as labels and need to be in the labels.pkl file
         lvalert = {'uid':graceid,
                    'alert_type':'signoff',
+                   'description': '',
                    'object': {'instrument':instrument, 'signoff_type':signoff_type, 'status':status},
                    'file':'',
                   }

--- a/lib/schedule.py
+++ b/lib/schedule.py
@@ -285,4 +285,31 @@ class WriteFile(Action):
         httpResponse = gdb.writeFile( self.graceDBevent.get_graceid(), filename=self.filename )
         return httpResponse
 
+class WriteSignoff(Action):
+    '''
+    create human or advocate signoff
+    '''
+    def __init__(self, dt, graceDBevent, instrument, signoff_type, status, gdb_url='https://gracedb.ligo.org/api'):
+        self.graceDBevent = graceDBevent
+        self.gdb_url = gdb_url
+
+        self.instrument   = instrument
+        self.signoff_type = signoff_type
+        self.status       = status
+        self.signoff = '{0}{1}'.format(self.instrument, self.status) if self.instrument else '{0}{1}'.format(self.signoff_type, self.status)
+
+        super(WriteSignoff, self).__init__(dt, self.writeSignoff)
+
+    def __str__(self):
+        return """WriteSignoff -> %s
+    randStr    : %s
+    graceid    : %s
+    signoff    : %s
+    timeout    : %.3f
+    expiration : %s"""%(self.gdb_url, self.graceDBevent.get_randStr(), self.graceDBevent.get_graceid(force=True), self.signoff, self.dt, "%.3f"%self.expiration if self.expiration else "None")
+
+    def writeSignoff(self, *args, **kwargs):
+        gdb = initGraceDb(self.gdb_url) ### delegate to work out whether we want GraceDb or FakeDb
+        httpResponse = gdb.writeSignoff( self.graceDBevent.get_graceid(), self.instrument, self.signoff_type, self.status )
+        return httpResponse
 


### PR DESCRIPTION
Creating operator and advocate lvalerts that are lvalert_type='signoff' rather than lvalert_type='label'.

this is needed for approval_processorMP's parseAlert to properly record the signoffs so that events can pass the signoffChecks